### PR TITLE
Support psr/container 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     "php": ">=7.0",
     "doctrine/annotations": "^1.3",
     "psr/cache": "^1.0",
-    "psr/container": "^1.0"
+    "psr/container": "^1.0 || ^2.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^8.0",
+    "phpunit/phpunit": "^9.0",
     "psx/cache": "^1.0"
   },
   "autoload": {
@@ -32,6 +32,6 @@
     }
   },
   "provide": {
-    "psr/container-implementation": "1.0"
+    "psr/container-implementation": "2.0"
   }
 }

--- a/src/Container.php
+++ b/src/Container.php
@@ -94,7 +94,7 @@ class Container implements ContainerInterface
      * @param string $name
      * @return boolean
      */
-    public function has($name)
+    public function has($name): bool
     {
         $name = self::normalizeName($name);
 

--- a/tests/ContainerTest.php
+++ b/tests/ContainerTest.php
@@ -20,6 +20,7 @@
 
 namespace PSX\Dependency\Tests;
 
+use Psr\Container\NotFoundExceptionInterface;
 use PHPUnit\Framework\TestCase;
 use PSX\Dependency\Container;
 
@@ -92,12 +93,11 @@ class ContainerTest extends TestCase
         $this->assertEquals($bar, $sc->get('bar'), '->get() prefers to return a service defined with set() than one defined with a getXXXMethod()');
     }
 
-    /**
-     * @expectedException \Psr\Container\NotFoundExceptionInterface
-     */
     public function testGetThrowServiceNotFoundException()
     {
         $sc = new Container();
+        
+        $this->expectException(NotFoundExceptionInterface::class);
         $sc->get('foo');
     }
 
@@ -115,12 +115,11 @@ class ContainerTest extends TestCase
         $this->assertEquals('baz1', $sc->getParameter('FOO'), '->getParameter() converts the key to lowercase');
     }
 
-    /**
-     * @expectedException \PSX\Dependency\NotFoundException
-     */
     public function testInvalidGetParameter()
     {
         $sc = new Container();
+        
+        $this->expectException(NotFoundExceptionInterface::class);
         $sc->getParameter('foobar');
     }
 

--- a/tests/ObjectBuilderTest.php
+++ b/tests/ObjectBuilderTest.php
@@ -20,6 +20,9 @@
 
 namespace PSX\Dependency\Tests;
 
+use InvalidArgumentException;
+use ReflectionException;
+use RuntimeException;
 use Doctrine\Common\Annotations\SimpleAnnotationReader;
 use Doctrine\Common\Cache\ArrayCache;
 use PHPUnit\Framework\TestCase;
@@ -52,25 +55,23 @@ class ObjectBuilderTest extends TestCase
         $this->assertNull($object->getProperty());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testGetObjectInjectUnknownService()
     {
         $container = new Container();
         
         $builder = $this->newObjectBuilder($container);
+        
+        $this->expectException(RuntimeException::class);
         $builder->getObject(Playground\FooService::class);
     }
 
-    /**
-     * @expectedException \ReflectionException
-     */
     public function testGetObjectUnknownClass()
     {
         $container = new Container();
         
         $builder = $this->newObjectBuilder($container);
+
+        $this->expectException(ReflectionException::class);
         $builder->getObject('PSX\Framework\Tests\Dependency\BarService');
     }
 
@@ -86,9 +87,6 @@ class ObjectBuilderTest extends TestCase
         $this->assertInstanceof(Playground\FooService::class, $object);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testGetObjectInstanceOfInvalid()
     {
         $container = new Container();
@@ -96,6 +94,8 @@ class ObjectBuilderTest extends TestCase
         $container->set('foo_bar', new \stdClass());
 
         $builder = $this->newObjectBuilder($container);
+
+        $this->expectException(InvalidArgumentException::class);
         $builder->getObject(Playground\FooService::class, array(), 'PSX\Framework\Tests\Dependency\BarService');
     }
 


### PR DESCRIPTION
* Upgrade phpunit to v9

I did not upgrade `psr/cache` because it would require a new release of `psx-cache`.

I am not sure what is appropriate to put in `provide` in `composer.json`.